### PR TITLE
Fixed to allow x-scrolling when the table overflows.

### DIFF
--- a/documents/src/components/HomepageUsages/index.js
+++ b/documents/src/components/HomepageUsages/index.js
@@ -25,7 +25,7 @@ export default function HomepageUsages() {
             description="homepage usage"
           />
         </h3>
-        <div>
+        <div className={clsx(styles.usageTableBox)}>
           <table className={clsx(styles.usageTable)}>
             <thead>
               <tr>

--- a/documents/src/components/HomepageUsages/styles.module.css
+++ b/documents/src/components/HomepageUsages/styles.module.css
@@ -5,6 +5,10 @@
   overflow: hidden;
 }
 
+.usageTableBox {
+  overflow-x: auto;
+}
+
 .usageTable {
   width: 100%;
   border: none;


### PR DESCRIPTION
- e.g. PC

![{594CF5F9-3AE7-47C1-BF52-A8A5C919D878}](https://github.com/user-attachments/assets/f2b11462-90f6-4408-8b6a-2b36e8ab7f41)

- e.g. Smartphone

![{FA9717EA-F11A-4C5B-AAC5-22D981CB8785}](https://github.com/user-attachments/assets/8609eea9-9faf-4f00-a3e9-3abf1628a7e7)
![{8257F06E-B4BB-43D2-919D-66E9EAD8D161}](https://github.com/user-attachments/assets/a6f143c1-b12d-4856-bd37-44019242c082)
