### PR TITLE
Fix license display logic

### DIFF
--- a/documents/src/components/HomepageUsages/index.js
+++ b/documents/src/components/HomepageUsages/index.js
@@ -95,7 +95,19 @@ function GhRepository({ owner }) {
           </a>
         </td>
         <td>{new Date(item.pushed_at).toLocaleDateString()}</td>
-        <td>{item.license?.name ?? "N/A"}</td>
+        <td>{convertLicense(item)}</td>
       </tr>
     ));
+}
+
+function convertLicense(item) {
+  if (item.license?.name == null || item.license?.url == null) {
+    return (
+      <a href={item.html_url} target="_blank" rel="noopener noreferrer">
+        See Repository
+      </a>
+    );
+  } else {
+    return item.license.name;
+  }
 }


### PR DESCRIPTION
- Displaying "N/A" when the license cannot be retrieved via API is inappropriate for complex licenses.
- Updated the message to instruct users to check the repository for the actual license details.
- see: https://github.com/FairyDevicesRD/thinklet.app.developer/issues/10