### PR TITLE
パスを省略していたので、省略せずにファイル名を明記

### DIFF
--- a/documents/docusaurus.config.js
+++ b/documents/docusaurus.config.js
@@ -88,11 +88,11 @@ const config = {
               },
               {
                 label: 'Operator Manual LC-01',
-                href: 'https://static-connected-worker.thinklet.fd.ai/support/ja/',
+                href: 'https://static-connected-worker.thinklet.fd.ai/support/ja/index.html',
               },
               {
                 label: 'Operator Manual LC-02',
-                href: 'https://static-connected-worker.thinklet.fd.ai/support/tl-cube/ja/',
+                href: 'https://static-connected-worker.thinklet.fd.ai/support/tl-cube/ja/index.html',
               },
               {
                 label: 'Software Licenses',

--- a/documents/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/documents/i18n/ja/docusaurus-theme-classic/footer.json
@@ -17,11 +17,11 @@
   },
   "link.item.label.Operator Manual LC-01": {
     "message": "THINKLET LC-01 取扱説明書",
-    "description": "The label of footer link with label=Operator Manual THINKLET linking to https://static-connected-worker.thinklet.fd.ai/support/ja/"
+    "description": "The label of footer link with label=Operator Manual THINKLET linking to https://static-connected-worker.thinklet.fd.ai/support/ja/index.html"
   },
   "link.item.label.Operator Manual LC-02": {
     "message": "THINKLET cube LC-02 取扱説明書",
-    "description": "The label of footer link with label=Operator Manual THINKLET cube linking to https://static-connected-worker.thinklet.fd.ai/support/tl-cube/ja/"
+    "description": "The label of footer link with label=Operator Manual THINKLET cube linking to https://static-connected-worker.thinklet.fd.ai/support/tl-cube/ja/index.html"
   },
   "link.item.label.Software Licenses": {
     "message": "Software Licenses",


### PR DESCRIPTION
# 期日
〜12/27（金）

# 目的
以下へのアクセスが `index.html` 無しになっていた

- https://static-connected-worker.thinklet.fd.ai/support/ja/index.html
- https://static-connected-worker.thinklet.fd.ai/support/tl-cube/ja/index.html

# 対応
URLに `index.html` を追記